### PR TITLE
Added title to Google Maps  iframe

### DIFF
--- a/src/Tags/Address.php
+++ b/src/Tags/Address.php
@@ -52,6 +52,7 @@ class Address extends Tags
 
         return <<<HTML
             <iframe
+              title="Google Maps"
               width="{$this->params->get('width', 640)}"
               height="{$this->params->get('height', 640)}"
               style="border:0"


### PR DESCRIPTION
To pass the Lighthouse accessibility test, iframes require the title attribute.

This change adds a title to the google maps iframe and will successfully pass the Lighthouse accessibility test.